### PR TITLE
Add button to make pikmin run to middle and exit left

### DIFF
--- a/main.py
+++ b/main.py
@@ -108,6 +108,7 @@ class RoutineName(enum.Enum):
     CROSS = "cross"
     SHAKE = "shake"
     JUMP = "jump"
+    EXIT_LEFT = "exit_left"
 
     @property
     def label(self) -> str:
@@ -115,6 +116,7 @@ class RoutineName(enum.Enum):
             "cross": "Walk across",
             "shake": "Shake in the middle",
             "jump": "Jump while running",
+            "exit_left": "Run to middle, exit left",
         }[self.value]
 
 
@@ -268,6 +270,7 @@ class PetView(QWidget):
             RoutineName.CROSS: self._routine_cross,
             RoutineName.SHAKE: self._routine_shake,
             RoutineName.JUMP: self._routine_jump,
+            RoutineName.EXIT_LEFT: self._routine_exit_left,
         }[name]
         self._start_routine(factory)
 
@@ -275,7 +278,7 @@ class PetView(QWidget):
 
     def _pick_random_routine(self) -> Callable[[], Routine]:
         return random.choice(
-            [self._routine_cross, self._routine_shake, self._routine_jump]
+            [self._routine_cross, self._routine_shake, self._routine_jump, self._routine_exit_left]
         )
 
     def _start_routine(self, factory: Callable[[], Routine]) -> None:
@@ -461,6 +464,27 @@ class PetView(QWidget):
             self._advance_walk_anim(dt)
             self._step_horizontal(dt)
 
+    def _routine_exit_left(self) -> Routine:
+        g = self._current_geometry()
+        self._enter_left(g)
+        middle_x = (g.left() + g.right()) / 2.0 - self.width() / 2.0
+        exit_x = g.left() - self.width() - EXIT_MARGIN_PX
+
+        # Run to the middle.
+        while self._fx < middle_x:
+            dt = (yield)
+            self._advance_walk_anim(dt)
+            self._step_horizontal(dt)
+
+        # Turn around and exit left.
+        self._direction = -1
+        self._walk_frame = 0
+        self._walk_acc_ms = 0
+        while self._fx > exit_x:
+            dt = (yield)
+            self._advance_walk_anim(dt)
+            self._step_horizontal(dt)
+
     # ---------- painting ----------
 
     def paintEvent(self, e: QPaintEvent) -> None:
@@ -522,6 +546,7 @@ ROUTINE_SHORT_LABEL = {
     RoutineName.CROSS: "Walk",
     RoutineName.SHAKE: "Shake",
     RoutineName.JUMP: "Jump",
+    RoutineName.EXIT_LEFT: "Exit Left",
 }
 
 PANEL_DEFAULT_MARGIN_PX = 16


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR implements a new feature that adds a button to make the pikmin run to the middle of the screen and then exit to the left.

Closes #6

## Changes Made

- Added new `RoutineName.EXIT_LEFT` enum value with label "Run to middle, exit left"
- Implemented `_routine_exit_left()` method that:
  - Makes the pikmin enter from the left
  - Runs to the middle of the screen
  - Turns around (reverses direction)
  - Exits to the left side
- Added "Exit Left" button to the control panel
- Included the new routine in random appearance selection

## Files Changed

- `main.py`: Added new routine and integrated it into the existing button system

## Testing Performed

- Verified Python syntax with `python3 -m py_compile main.py` (passes)
- Installed PyQt6 dependencies successfully
- Code follows the existing pattern for routines (similar to `_routine_shake`)

## How It Works

The new routine follows this sequence:
1. Enter from the left side of the screen (like all other routines)
2. Run to the middle using `_step_horizontal()` with `_direction = 1`
3. Once at middle position, flip direction to `-1`
4. Continue running left until exiting off the left edge

The "Exit Left" button appears in the control panel alongside Walk, Shake, and Jump buttons.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca018f54-52c3-4f66-9886-b8029ff51bf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca018f54-52c3-4f66-9886-b8029ff51bf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

